### PR TITLE
ACME_DOMAIN environment variable missing - fixes #20385

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,8 +98,9 @@ func main() {
 			Value: "simple",
 		},
 		cli.StringSliceFlag{
-			Name:  "acme-domain",
-			Usage: "Domain to register with LetsEncrypt",
+			Name:   "acme-domain",
+			EnvVar: "ACME_DOMAIN",
+			Usage:  "Domain to register with LetsEncrypt",
 		},
 		cli.BoolFlag{
 			Name:  "no-cacerts",


### PR DESCRIPTION
With --acme-domain availability as environment variable it's possible to run rancher/rancher image
on Azure Container Instances and get a valid offical Letsencrypt certificate instead self-signed.
This helps enterprises who are using proxies which evaluate SSL certificates.